### PR TITLE
Upgrade Vivado to 2018.3 

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,13 @@ sudo pip3.6 install --upgrade git+https://github.com/xupsh/pp4fpgas-cn-hls.git
 ├── hw
 │   ├── build_ip.tcl
 │   └── cordic/dft/fft/fir/histogram/huffman/matrixm/sort/spmv/sum/vs
-│   	├── *_wrapper.v
-│   	└── build_*.tcl
+│   │ ├── *_wrapper.v
+│   │ └── build_*.tcl
+│   └── ip
+│     └── cordic/dft/fft/fir/histogram/huffman/matrixm/sort/spmv/sum/vs
+│       └── *.cpp
+│       └── *.h
+│
 ├── pp4fpgas
 │   ├── __init__.py
 │   └── cordic/dft/fft/fir/histogram/huffman/matrixm/sort/spmv/sum/vs

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ sudo pip3.6 install --upgrade git+https://github.com/xupsh/pp4fpgas-cn-hls.git
 > version required: vivado 2018.3  
 > make sure you already have these board files in your vivado  
 > https://github.com/xupsh/pynq-supported-board-file  
-> take CORDIC on Pynq-Z2 design as an example  
+> take CORDIC on Pynq-Z2 as an example design 
 
 - Open your vivado gui and find `tcl console`
 - `cd` the path you git clone

--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ sudo pip3.6 install --upgrade git+https://github.com/xupsh/pp4fpgas-cn-hls.git
 ```
 
 ## Hardware Design Rebuilt
-> version required: vivado 2018.3
-> make sure you already have these board files in your vivado
-> https://github.com/xupsh/pynq-supported-board-file
+> version required: vivado 2018.3  
+> make sure you already have these board files in your vivado  
+> https://github.com/xupsh/pynq-supported-board-file  
 > take CORDIC on Pynq-Z2 design as an example  
 
 - Open your vivado gui and find `tcl console`

--- a/README.md
+++ b/README.md
@@ -48,14 +48,17 @@ sudo pip3.6 install --upgrade git+https://github.com/xupsh/pp4fpgas-cn-hls.git
 ```
 
 ## Hardware Design Rebuilt
-> version required: vivado 2017.4
+> version required: vivado 2018.3
 > make sure you already have these board files in your vivado
 > https://github.com/xupsh/pynq-supported-board-file
+> take CORDIC on Pynq-Z2 design as an example  
 
 - Open your vivado gui and find `tcl console`
 - `cd` the path you git clone
 - `cd` hw directory
 - `source build_ip.tcl`
+- `cd <the path you git clone>/boards/Pynq-Z2/cordic/`  
+- `source cordic.tcl`  
 
 ![tcl console](./boards/Pynq-Z1/notebooks/data/tclconsole.png)
 

--- a/boards/Pynq-Z1/cordic/cordic.tcl
+++ b/boards/Pynq-Z1/cordic/cordic.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg400-1
    set_property BOARD_PART www.digilentinc.com:pynq-z1:part0:1.0 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/dft/dft.tcl
+++ b/boards/Pynq-Z1/dft/dft.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/fft/fft.tcl
+++ b/boards/Pynq-Z1/fft/fft.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/fir/fir.tcl
+++ b/boards/Pynq-Z1/fir/fir.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/histogram/histogram.tcl
+++ b/boards/Pynq-Z1/histogram/histogram.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/huffman/huffman.tcl
+++ b/boards/Pynq-Z1/huffman/huffman.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/matrixm/matrixm.tcl
+++ b/boards/Pynq-Z1/matrixm/matrixm.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/sort/sort.tcl
+++ b/boards/Pynq-Z1/sort/sort.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/spmv/spmv.tcl
+++ b/boards/Pynq-Z1/spmv/spmv.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/sum/sum.tcl
+++ b/boards/Pynq-Z1/sum/sum.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z1/vs/vs.tcl
+++ b/boards/Pynq-Z1/vs/vs.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -46,6 +46,11 @@ if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg484-1
    set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
+
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z2/cordic/cordic.tcl
+++ b/boards/Pynq-Z2/cordic/cordic.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -44,9 +44,12 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
    create_project project_1 myproj -part xc7z020clg400-1
-   set_property BOARD_PART www.digilentinc.com:pynq-z1:part0:1.0 [current_project]
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
 
 # CHANGE DESIGN NAME HERE
 variable design_name

--- a/boards/Pynq-Z2/dft/dft.tcl
+++ b/boards/Pynq-Z2/dft/dft.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,9 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z2/fft/fft.tcl
+++ b/boards/Pynq-Z2/fft/fft.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name fft

--- a/boards/Pynq-Z2/fir/fir.tcl
+++ b/boards/Pynq-Z2/fir/fir.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name design_1

--- a/boards/Pynq-Z2/histogram/histogram.tcl
+++ b/boards/Pynq-Z2/histogram/histogram.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name design_1

--- a/boards/Pynq-Z2/huffman/huffman.tcl
+++ b/boards/Pynq-Z2/huffman/huffman.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name design_1

--- a/boards/Pynq-Z2/matrixm/matrixm.tcl
+++ b/boards/Pynq-Z2/matrixm/matrixm.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name design_1

--- a/boards/Pynq-Z2/sort/sort.tcl
+++ b/boards/Pynq-Z2/sort/sort.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name design_1

--- a/boards/Pynq-Z2/spmv/spmv.tcl
+++ b/boards/Pynq-Z2/spmv/spmv.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name design_1

--- a/boards/Pynq-Z2/sum/sum.tcl
+++ b/boards/Pynq-Z2/sum/sum.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,9 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
+
+set_property  ip_repo_paths ../../../hw/ip [current_project]
+
+update_ip_catalog
 
 
 # CHANGE DESIGN NAME HERE

--- a/boards/Pynq-Z2/vs/vs.tcl
+++ b/boards/Pynq-Z2/vs/vs.tcl
@@ -20,7 +20,7 @@ set script_folder [_tcl::get_script_folder]
 ################################################################
 # Check if script is running in correct Vivado version.
 ################################################################
-set scripts_vivado_version 2017.4
+set scripts_vivado_version 2018.3
 set current_vivado_version [version -short]
 
 if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
@@ -43,11 +43,13 @@ if { [string first $scripts_vivado_version $current_vivado_version] == -1 } {
 
 set list_projs [get_projects -quiet]
 if { $list_projs eq "" } {
-   create_project project_1 myproj -part xc7z020clg484-1
-   set_property BOARD_PART xilinx.com:zc702:part0:1.3 [current_project]
+   create_project project_1 myproj -part xc7z020clg400-1
+   set_property BOARD_PART tul.com.tw:pynq-z2:part0:1.0 [current_project]
 }
 
+set_property  ip_repo_paths ../../../hw/ip [current_project]
 
+update_ip_catalog
 # CHANGE DESIGN NAME HERE
 variable design_name
 set design_name design_1


### PR DESCRIPTION
- Now Vivado 2018.3 can be used to rebuild designs.
- Extra steps to rebuild a certain project are added to Readme.
- File hierarchy is more clear in Readme.